### PR TITLE
Competitor warnings

### DIFF
--- a/.markdown-proofing
+++ b/.markdown-proofing
@@ -46,6 +46,6 @@
     "aca-branding-error": "error",
     "aca-branding-warning": "warning",
 
-    "disallowed-phrases": "error"
+    "disallowed-phrases": "warning"
   }
 }

--- a/src/analysers/disallowed-phrases.ts
+++ b/src/analysers/disallowed-phrases.ts
@@ -3,8 +3,8 @@ import { RegExpAnalyserRule, RegExpAnalyser } from './tools/regexp-analyser';
 const rules: RegExpAnalyserRule[] = [
     ['disallowed-phrases', [
         [
-            // Check for mentions of competitors.
-            /\b(AMX)|(Crestron)|(Extron)\b/gi,
+            // Check for mentions of competitors in text outside of links.
+            /(\b(AMX)|(Crestron)|(Extron)\b)(?![^\[]*\]\([^\(]*\))/gi,
             `don't be a dick and talk down competitors - they build nice things too`
         ]
     ]],


### PR DESCRIPTION
Loosen constraints for mentions of other brands within docs to provide the ability to link to reference module implementations.