### PR TITLE
Fix broken pricing link

### DIFF
--- a/src/app/docsify-conf.ts
+++ b/src/app/docsify-conf.ts
@@ -5,7 +5,7 @@ import { docsifyReplace } from './docsify-replace';
  * Plugin to auto-insert a hairline space in all instances of "ACAEngine" to
  * keep nice typography.
  */
-const insertHairline: Plugin = docsifyReplace(/ACAEngine/gi, 'ACA&#8202;Engine');
+const insertHairline: Plugin = docsifyReplace(/\bACAEngine\b/gi, 'ACA&#8202;Engine');
 
 /**
  * Site config to be picked up by docsify for rendering of site.


### PR DESCRIPTION
Insertion of hairline spaces into 'ACAEngine' as part of render would break links containing the phrase.